### PR TITLE
Remove dependency on scalatest in proptics-law

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,7 @@ lazy val law = crossProject(JVMPlatform, JSPlatform)
   .dependsOn(core, profunctor)
   .settings(stdProjectSettings("law"))
   .settings(crossProjectSettings)
-  .settings(libraryDependencies ++= Seq(cats.value, catsLaws.value, discipline.value, disciplineScalatest.value))
+  .settings(libraryDependencies ++= Seq(cats.value, catsLaws.value, discipline.value))
   .settings(additionalDependencies)
 
 lazy val test = crossProject(JVMPlatform, JSPlatform)


### PR DESCRIPTION
The dependency is unused, and makes cross-building slightly vexing due to conflict with `scala-xml`. As a workaround, one can use

```
ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
```